### PR TITLE
CB2-1728 add retry logic to database call

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import 'source-map-support/register';
-import { ScheduledEvent } from 'aws-lambda';
+import { ScheduledEvent, Context, Callback } from 'aws-lambda';
 import { sendEvents } from './eventbridge/send';
 import { getEvents } from './wms/ExportEvents';
 import logger from './observability/logger';
@@ -13,7 +13,7 @@ logger.debug(
   `\nRunning Service:\n '${SERVICE}'\n mode: ${NODE_ENV}\n stage: '${AWS_STAGE}'\n region: '${AWS_REGION}'\n\n`,
 );
 
-const handler = async (event: ScheduledEvent): Promise<{ statusCode: number; body: string }> => {
+const handler = async (event: ScheduledEvent, _context: Context, callback: Callback) => {
   try {
     logger.debug(`Function triggered with '${JSON.stringify(event)}'.`);
 
@@ -28,12 +28,11 @@ const handler = async (event: ScheduledEvent): Promise<{ statusCode: number; bod
     await sendEvents(facilitySchedules);
 
     logger.info('Data processed successfully.');
-    return { statusCode: 200, body: 'Data processed successfully.' };
+    callback(null, 'Data processed successfully.');
   } catch (error) {
     logger.info('Data processed unsuccessfully.');
     logger.error('', error);
-
-    return { statusCode: 500, body: 'Data processed unsuccessfully.' };
+    callback(new Error('Data processed unsuccessfully.'));
   }
 };
 

--- a/tests/unit/handler.test.ts
+++ b/tests/unit/handler.test.ts
@@ -36,37 +36,39 @@ describe('Application entry', () => {
   });
 
   describe('Handler', () => {
-    it('GIVEN a call to the function WHEN events are processed succesfully THEN a 200 is returned.', async () => {
+    it('GIVEN a call to the function WHEN events are processed succesfully THEN a callback result is returned.', async () => {
       const mSendResponse: SendResponse = { SuccessCount: 1, FailCount: 0 };
       mocked(sendEvents).mockResolvedValue(mSendResponse);
-      const response: { statusCode: number; body: string } = await handler(event);
-      expect(response.statusCode).toEqual(200);
-      expect(typeof response.body).toBe('string');
+      await handler(event, null, (error: string | Error, result: string) => {
+        expect(result).toEqual('Data processed successfully.');
+        expect(error).toBeNull();
+      });
     });
 
-    it('GIVEN a call to the function WHEN events are processed unsuccesfully THEN a 500 is returned.', async () => {
+    it('GIVEN a call to the function WHEN events are processed unsuccesfully THEN a callback error is returned.', async () => {
       mocked(sendEvents).mockRejectedValue(new Error('Oh no!'));
-      const response: { statusCode: number; body: string } = await handler(event);
-      expect(response.statusCode).toEqual(500);
-      expect(typeof response.body).toBe('string');
+      await handler(event, null, (error: string | Error, result: string) => {
+        expect(error).toEqual(new Error('Data processed unsuccessfully.'));
+        expect(result).toBeUndefined();
+      });
     });
 
     it('GIVEN a call to the function WHEN no date is passed in THEN the database is called with the current date.', async () => {
       jest.spyOn(global.Date, 'now').mockImplementation(() => new Date('2021-10-10T11:02:28.637Z').valueOf());
-      await handler(event);
+      await handler(event, null, () => {});
       expect(getEvents).toBeCalledWith(new Date(Date.now()));
     });
 
     it('GIVEN a call to the function WHEN a date is passed in THEN the database is called with that date.', async () => {
       event.detail = { exportDate: '2021-11-11' };
-      await handler(event);
+      await handler(event, null, () => {});
       expect(getEvents).toBeCalledWith(new Date('2021-11-11'));
     });
 
     it('GIVEN a call to the function WHEN an invalid date is passed in THEN an error is thrown.', async () => {
       event.detail = { exportDate: 'I am not a date!' };
       const error = new Error(`Failed to manually trigger function. Invalid input date ${event.detail.exportDate}`);
-      await handler(event).catch((err) => {
+      await handler(event, null, () => {}).catch((err) => {
         expect(logger.error).toHaveBeenCalledTimes(1);
         expect(logger.error).toHaveBeenCalledWith(error);
         expect(err).toBe(error);


### PR DESCRIPTION
Changes made so the retry policy of eventbridge can be used to handle the retry logic.