### PR TITLE
CB2-2087: added better error handling

### DIFF
--- a/src/wms/Database.ts
+++ b/src/wms/Database.ts
@@ -46,13 +46,13 @@ export class Database {
     logger.info('getstaffSchedules starting');
     const secret: string[] = await getSecret(process.env.SECRET_NAME);
     const query = await this.connection
-      .select('ngt_site.c_id', 'ngt_staff.staff_id', 'status', 'event_date', 'event_start', 'event_end')
-      .from<StaffSchedule>('ngt_site_events')
-      .innerJoin('ngt_staff', 'ngt_site_events.staff_id', 'ngt_staff.id')
-      .innerJoin('ngt_site', 'ngt_site_events.site_id', 'ngt_site.id')
+      .select('NGT_SITE.C_ID', 'NGT_STAFF.STAFF_ID', 'STATUS', 'EVENT_DATE', 'EVENT_START', 'EVENT_END')
+      .from<StaffSchedule>('NGT_SITE_EVENTS')
+      .innerJoin('NGT_STAFF', 'NGT_SITE_EVENTS.STAFF_ID', 'NGT_STAFF.ID')
+      .innerJoin('NGT_SITE', 'NGT_SITE_EVENTS.SITE_ID', 'NGT_SITE.ID')
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      .where('event_date', '=', dateformat(exportDate, 'yyyy-mm-dd'))
-      .havingIn('ngt_site.c_id', secret);
+      .where('EVENT_DATE', '=', dateformat(exportDate, 'yyyy-mm-dd'))
+      .havingIn('NGT_SITE.C_ID', secret);
 
     logger.info('getstaffSchedules ending');
     return query as StaffSchedule[];

--- a/src/wms/Database.ts
+++ b/src/wms/Database.ts
@@ -52,6 +52,7 @@ export class Database {
       .innerJoin('NGT_SITE', 'NGT_SITE_EVENTS.SITE_ID', 'NGT_SITE.ID')
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       .where('EVENT_DATE', '=', dateformat(exportDate, 'yyyy-mm-dd'))
+      .where('STATUS', 'ALLOCATED')
       .havingIn('NGT_SITE.C_ID', secret);
 
     logger.info('getstaffSchedules ending');

--- a/src/wms/Database.ts
+++ b/src/wms/Database.ts
@@ -57,7 +57,7 @@ export class Database {
 
     logger.info('getstaffSchedules ending');
 
-    if (query.length <= 0) {
+    if (query.length === 0) {
       throw new EvalError('No daily schedules found in WMS, check coneection or content');
     }
     return query as StaffSchedule[];

--- a/src/wms/Database.ts
+++ b/src/wms/Database.ts
@@ -56,6 +56,10 @@ export class Database {
       .havingIn('NGT_SITE.C_ID', secret);
 
     logger.info('getstaffSchedules ending');
+
+    if (query.length <= 0) {
+      throw new EvalError('No daily schedules found in WMS, check coneection or content');
+    }
     return query as StaffSchedule[];
   }
 

--- a/src/wms/ExportEvents.ts
+++ b/src/wms/ExportEvents.ts
@@ -37,6 +37,7 @@ export async function getEvents(exportDate: Date): Promise<FacillitySchedules[]>
     });
   } catch (error) {
     database.closeConnection().catch((e) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       logger.error(e);
     });
     throw error;

--- a/tests/unit/database.test.ts
+++ b/tests/unit/database.test.ts
@@ -68,6 +68,7 @@ describe('Database calls', () => {
       expect(mKnex.innerJoin).toBeCalledWith('NGT_SITE', 'NGT_SITE_EVENTS.SITE_ID', 'NGT_SITE.ID');
       expect(mKnex.from).toBeCalledWith('NGT_SITE_EVENTS');
       expect(mKnex.where).toBeCalledWith('EVENT_DATE', '=', '2021-10-10');
+      expect(mKnex.where).toBeCalledWith('STATUS', 'ALLOCATED');
       expect(mKnex.havingIn).toBeCalledWith('NGT_SITE.C_ID', ['100', '101']);
       expect(staffSchedules).toHaveLength(1);
     });

--- a/tests/unit/database.test.ts
+++ b/tests/unit/database.test.ts
@@ -25,7 +25,7 @@ const ent = {
   event_start: 'string',
   event_end: 'string',
 };
-const mKnex = ({
+let mKnex = ({
   select: jest.fn().mockReturnThis(),
   innerJoin: jest.fn().mockReturnThis(),
   from: jest.fn().mockReturnThis(),
@@ -71,6 +71,42 @@ describe('Database calls', () => {
       expect(mKnex.where).toBeCalledWith('STATUS', 'ALLOCATED');
       expect(mKnex.havingIn).toBeCalledWith('NGT_SITE.C_ID', ['100', '101']);
       expect(staffSchedules).toHaveLength(1);
+    });
+
+    it('GIVEN a call to getstaffSchedules WHEN empty list returned THEN error thrown.', async () => {
+      mKnex = ({
+        select: jest.fn().mockReturnThis(),
+        innerJoin: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        havingIn: jest.fn(() => []),
+        destroy: jest.fn().mockResolvedValue('destroyed'),
+      } as unknown) as Knex;
+
+      const database = new Database();
+      const filters: string[] = new Array<string>('100', '101');
+      const nullError = new EvalError('No daily schedules found in WMS, check coneection or content');
+      mocked(getSecret).mockResolvedValue(filters);
+
+      jest.spyOn(global.Date, 'now').mockImplementationOnce(() => new Date('2021-10-10T11:02:28.637Z').valueOf());
+
+      await database.getstaffSchedules(exportDate).catch((error) => {
+        expect(error).toEqual(nullError);
+      });
+      expect(mKnex.select).toBeCalledWith(
+        'NGT_SITE.C_ID',
+        'NGT_STAFF.STAFF_ID',
+        'STATUS',
+        'EVENT_DATE',
+        'EVENT_START',
+        'EVENT_END',
+      );
+      expect(mKnex.innerJoin).toBeCalledWith('NGT_STAFF', 'NGT_SITE_EVENTS.STAFF_ID', 'NGT_STAFF.ID');
+      expect(mKnex.innerJoin).toBeCalledWith('NGT_SITE', 'NGT_SITE_EVENTS.SITE_ID', 'NGT_SITE.ID');
+      expect(mKnex.from).toBeCalledWith('NGT_SITE_EVENTS');
+      expect(mKnex.where).toBeCalledWith('EVENT_DATE', '=', '2021-10-10');
+      expect(mKnex.where).toBeCalledWith('STATUS', 'ALLOCATED');
+      expect(mKnex.havingIn).toBeCalledWith('NGT_SITE.C_ID', ['100', '101']);
     });
 
     it('GIVEN a call to closeConnection WHEN everything works THEN we get no errors.', async () => {

--- a/tests/unit/database.test.ts
+++ b/tests/unit/database.test.ts
@@ -57,18 +57,18 @@ describe('Database calls', () => {
 
       const staffSchedules: StaffSchedule[] = await database.getstaffSchedules(exportDate);
       expect(mKnex.select).toBeCalledWith(
-        'ngt_site.c_id',
-        'ngt_staff.staff_id',
-        'status',
-        'event_date',
-        'event_start',
-        'event_end',
+        'NGT_SITE.C_ID',
+        'NGT_STAFF.STAFF_ID',
+        'STATUS',
+        'EVENT_DATE',
+        'EVENT_START',
+        'EVENT_END',
       );
-      expect(mKnex.innerJoin).toBeCalledWith('ngt_staff', 'ngt_site_events.staff_id', 'ngt_staff.id');
-      expect(mKnex.innerJoin).toBeCalledWith('ngt_site', 'ngt_site_events.site_id', 'ngt_site.id');
-      expect(mKnex.from).toBeCalledWith('ngt_site_events');
-      expect(mKnex.where).toBeCalledWith('event_date', '=', '2021-10-10');
-      expect(mKnex.havingIn).toBeCalledWith('ngt_site.c_id', ['100', '101']);
+      expect(mKnex.innerJoin).toBeCalledWith('NGT_STAFF', 'NGT_SITE_EVENTS.STAFF_ID', 'NGT_STAFF.ID');
+      expect(mKnex.innerJoin).toBeCalledWith('NGT_SITE', 'NGT_SITE_EVENTS.SITE_ID', 'NGT_SITE.ID');
+      expect(mKnex.from).toBeCalledWith('NGT_SITE_EVENTS');
+      expect(mKnex.where).toBeCalledWith('EVENT_DATE', '=', '2021-10-10');
+      expect(mKnex.havingIn).toBeCalledWith('NGT_SITE.C_ID', ['100', '101']);
       expect(staffSchedules).toHaveLength(1);
     });
 

--- a/tests/unit/database.test.ts
+++ b/tests/unit/database.test.ts
@@ -101,8 +101,8 @@ describe('Database calls', () => {
         'EVENT_START',
         'EVENT_END',
       );
-      expect(mKnex.innerJoin).toBeCalledWith('NGT_STAFF', 'NGT_SITE_EVENTS.STAFF_ID', 'NGT_STAFF.ID');
-      expect(mKnex.innerJoin).toBeCalledWith('NGT_SITE', 'NGT_SITE_EVENTS.SITE_ID', 'NGT_SITE.ID');
+      expect(mKnex.innerJoin).toBeCalledWith('NGT_STAFF', 'NGT_SITE_EVENTS.STAFF_ID', 'NGT_STAFF.STAFF_ID');
+      expect(mKnex.innerJoin).toBeCalledWith('NGT_SITE', 'NGT_SITE_EVENTS.SITE_ID', 'NGT_SITE.SITE_ID');
       expect(mKnex.from).toBeCalledWith('NGT_SITE_EVENTS');
       expect(mKnex.where).toBeCalledWith('EVENT_DATE', '=', '2021-10-10');
       expect(mKnex.where).toBeCalledWith('STATUS', 'ALLOCATED');


### PR DESCRIPTION
Bug:
https://jira.dvsacloud.uk/browse/CB2-2807


After consulting PO Sarah Smith, we do want the error to occur if there is no scheduling data but to be handled better. instead of event.Records is not iterable.