### PR TITLE
fix(cb2-2605): force staff_id to be an integer

### DIFF
--- a/src/wms/Database.ts
+++ b/src/wms/Database.ts
@@ -9,7 +9,7 @@ import { StaffSchedule } from './Interfaces/StaffSchedule';
 
 interface SqlQueryResults {
   C_ID: string;
-  STAFF_ID: number;
+  STAFF_ID: string;
   STATUS: string;
   EVENT_DATE: string;
   EVENT_START: string;
@@ -84,7 +84,7 @@ export class Database {
 
       const schedule: StaffSchedule = {
         c_id: q.C_ID,
-        staff_id: q.STAFF_ID,
+        staff_id: parseInt(q.STAFF_ID, 10),
         status: q.STATUS,
         event_date: q.EVENT_DATE.split(' ')[0], // We only want the date part from "YYYY-MM-DD 00:00:00"
         event_start: q.EVENT_START,


### PR DESCRIPTION
## Only open a single order header when a new schedule is created
Lambda was converting integer input from WMS database into a string which caused validation errors on Dynamics' side when receiving events from eventbridge, this fix forces staff_id to be an integer so that Dynamics validation checks pass.

Before:
![image](https://user-images.githubusercontent.com/92087051/155703054-f0fad613-9b9d-445b-a1fd-2470fa2db888.png)
Now:
![image](https://user-images.githubusercontent.com/92087051/155703237-2fdc9dcb-6ba2-40a5-9195-a3b98bd7f332.png)

[link to ticket number](https://jira.dvsacloud.uk/browse/CB2-2605)

## Checklist
- [X] Code has been tested manually
- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [X] Squashed commit contains the JIRA ticket number